### PR TITLE
改了一行，解决merge后 CI 挂掉的问题

### DIFF
--- a/source/chapter3/6answer.rst
+++ b/source/chapter3/6answer.rst
@@ -579,7 +579,7 @@ iv. 任务结束
 ``spp``\ 位做判断，如果为0则是用户态中断，否则是内核态中断。类似地，在中断返回时也要做一次判断。将
 ``__restore`` 改为：
 
-.. code:: asm
+.. code:: 
 
    __restore:
        # now sp->kernel stack(after allocated), sscratch->user stack


### PR DESCRIPTION
看了一下 CI 挂了，发现是因为有段代码引用的 `trap.S`，里面用了宏：
```
       .set n, 5
       .rept 27
           LOAD_GP %n
           .set n, n+1
       .endr
```
但 sphinx 似乎并不能识别宏，代码高亮失败报错。我本机报的 WARNING，但 CI 里要求无 WARNING 所以它 ERROR 了。

总之把描述的 `.. code:: asm` 删了，就这一个修改，肥肠抱歉打扰