### PR TITLE
idx should always increase

### DIFF
--- a/source/chapter9/2device-driver-2.rst
+++ b/source/chapter9/2device-driver-2.rst
@@ -478,7 +478,7 @@ virtio驱动程序
 
    avail.ring[(avail.idx + added++) % qsz] = head;
 
-idx总是递增，并在到达 ``qsz`` 后又回到0：
+idx总是递增，在模以 ``qsz`` 后才能进行取描述符的操作：
 
 .. code-block:: Rust
 


### PR DESCRIPTION
Hi, 

>    "idx总是递增的， 并且到达qsz后又回到0 是想表达 % qsz变成0吗"
### Problem:
I've discovered that the 'idx' variable may need to increment continuously and fetch the descriptor after applying the modulus operator. This necessity arises because my custom frontend driver operates optimally only when 'avail.idx' increases without wrapping around. Similarly, the backend utilizes 'used.idx,' which also increases without wrapping.
### Proof
 I'm employing the virtio non-legacy mode along with vrtio-blk to write 4096 blocks. Interestingly, I've observed that the frontend driver performs effectively when 'idx' doesn't wrap around.